### PR TITLE
fix eslint config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,2 @@
+'use strict';
+module.exports = require('eslint-config-strongloop');

--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
     "test/"
   ],
   "devDependencies": {
-    "eslint": "^3.19.0",
+    "eslint": "^5.9.0",
     "eslint-config-strongloop": "^2.1.0",
-    "tap": "^10.7.3"
+    "tap": "^12.1.0"
   },
   "dependencies": {},
   "os": ["win32"]

--- a/test/test.js
+++ b/test/test.js
@@ -14,8 +14,8 @@
  * limitations under the License.
  ************************************************************************/
 'use strict';
-const chcp = require('../index');
-const tap = require('tap');
+var chcp = require('../index');
+var tap = require('tap');
 
 var cp = chcp.getConsoleCodePage();
 var cp1 = 0;


### PR DESCRIPTION
fix error for run `npm run lint`:

```bash
D:\work\chcp>npm run lint

> chcp@1.0.0 lint D:\work\chcp
> eslint .


Oops! Something went wrong! :(

ESLint: 5.9.0.
ESLint couldn't find a configuration file. To set up a configuration file for this project, please run:

    eslint --init

ESLint looked for configuration files in D:\work\chcp and its ancestors. If it found none, it then looked in your home directory.

If you think you already have a configuration file or if you need more help, please stop by the ESLint chat room: https://gitter.im/eslint/eslint

npm ERR! code ELIFECYCLE
npm ERR! errno 2
npm ERR! chcp@1.0.0 lint: `eslint .`
npm ERR! Exit status 2
npm ERR!
npm ERR! Failed at the chcp@1.0.0 lint script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
```
